### PR TITLE
Filled missing locale

### DIFF
--- a/src/message/languages/en/setting.json
+++ b/src/message/languages/en/setting.json
@@ -1,0 +1,9 @@
+{
+  "list": "List Setting Success.",
+  "get": "Get Setting Success.",
+  "getByName": "Get Setting by name Success.",
+  "update": "Update Succeed",
+  "error": {
+      "notFound": "Setting not found"
+  }
+}


### PR DESCRIPTION
Hi @andrechristikan 

Setting locale has been filled.
I found an unimplemented function `getByName` in the setting service.
I'll try it and open another pr.