### PR TITLE
hot fix: import class response paging

### DIFF
--- a/src/common/request/interfaces/request.interface.ts
+++ b/src/common/request/interfaces/request.interface.ts
@@ -1,7 +1,7 @@
 import { Request } from 'express';
 import { ApiKeyPayloadDto } from 'src/modules/api-key/dtos/api-key.payload.dto';
 import { AuthJwtAccessPayloadDto } from 'src/modules/auth/dtos/jwt/auth.jwt.access-payload.dto';
-import { ResponsePagingMetadataPaginationDto } from 'src/common/response/dtos/response.paging.dto';
+import { ResponsePagingMetadataPaginationRequestDto } from 'src/common/response/dtos/response.paging.dto';
 
 export interface IRequestApp<T = AuthJwtAccessPayloadDto, B = ApiKeyPayloadDto>
     extends Request {
@@ -12,5 +12,5 @@ export interface IRequestApp<T = AuthJwtAccessPayloadDto, B = ApiKeyPayloadDto>
     __language: string;
     __version: string;
 
-    __pagination?: ResponsePagingMetadataPaginationDto;
+    __pagination?: ResponsePagingMetadataPaginationRequestDto;
 }


### PR DESCRIPTION
You changed the class name but didn't check what was called, check in the following commit:

https://github.com/andrechristikan/ack-nestjs-boilerplate/commit/cbf4b5a1a0ef2dc9b06702573fbb4d41d30f0cdd#diff-b4a53b729f74a91c2843e38f7a3765c6018bdf916d0342ce9dc9f80aaeefbcd5

<img width="1186" alt="Screen Shot 2024-11-21 at 22 33 35" src="https://github.com/user-attachments/assets/ec4c0c32-4450-49c7-91ea-d5974f8af57c">
