### PR TITLE
fix redis cache no default ttl

### DIFF
--- a/src/common/common.module.ts
+++ b/src/common/common.module.ts
@@ -79,6 +79,7 @@ import { LoggerOptionService } from 'src/common/logger/services/logger.option.se
                     password: configService.get<string>(
                         'redis.cached.password'
                     ),
+                    ttl: configService.get<number>('redis.cached.ttl'),
                 });
 
                 return {


### PR DESCRIPTION
Please double check cache time to live with redis, i think this is actually the right option to set default TTL
