### PR TITLE
fix: signup reports no 'user' role

### DIFF
--- a/src/modules/auth/controllers/auth.public.controller.ts
+++ b/src/modules/auth/controllers/auth.public.controller.ts
@@ -341,7 +341,7 @@ export class AuthPublicController {
         { email, name, password: passwordString, country }: AuthSignUpRequestDto
     ): Promise<void> {
         const promises: Promise<any>[] = [
-            this.roleService.findOneByName('user'),
+            this.roleService.findOneByName('individual'),
             this.userService.existByEmail(email),
             this.countryService.findOneById(country),
         ];


### PR DESCRIPTION
- correct role name to 'individual' as per migration.role.seed.ts