### PR TITLE
fix: Correct logical issues in AuthSharedController.changePassword()

### DIFF
--- a/src/common/helper/services/helper.date.service.ts
+++ b/src/common/helper/services/helper.date.service.ts
@@ -80,7 +80,7 @@ export class HelperDateService implements IHelperDateService {
     }
 
     create(date?: Date, options?: IHelperDateCreateOptions): Date {
-        const mDate = date
+        let mDate = date
             ? DateTime.fromJSDate(date).setZone(this.defTz)
             : DateTime.now().setZone(this.defTz);
 
@@ -88,12 +88,12 @@ export class HelperDateService implements IHelperDateService {
             options?.dayOf &&
             options?.dayOf === ENUM_HELPER_DATE_DAY_OF.START
         ) {
-            mDate.startOf('day');
+            mDate = mDate.startOf('day');
         } else if (
             options?.dayOf &&
             options?.dayOf === ENUM_HELPER_DATE_DAY_OF.END
         ) {
-            mDate.endOf('day');
+            mDate = mDate.endOf('day');
         }
 
         return mDate.toJSDate();

--- a/src/configs/auth.config.ts
+++ b/src/configs/auth.config.ts
@@ -46,7 +46,7 @@ export default registerAs(
             saltLength: 8,
             expiredIn: ms('182d') / 1000, // 0.5 years
             expiredInTemporary: ms('3d') / 1000, // 3 days
-            period: ms('90d') / 1000, // 3 months
+            period: ms('90d') / 86400000, // 3 months
         },
 
         apple: {

--- a/src/languages/en/auth.json
+++ b/src/languages/en/auth.json
@@ -14,6 +14,6 @@
         "passwordExpired": "Your password has expired.",
         "passwordAttemptMax": "Maximum password attempts exceeded.",
         "passwordNotMatch": "Passwords do not match.",
-        "passwordMustNew": "New password must be different from previous passwords within {period}."
+        "passwordMustNew": "New password must be different from previous passwords within the past {period} days."
     }
 }

--- a/src/modules/auth/controllers/auth.shared.controller.ts
+++ b/src/modules/auth/controllers/auth.shared.controller.ts
@@ -150,7 +150,6 @@ export class AuthSharedController {
                     customProperty: {
                         messageProperties: {
                             period: passwordPeriod,
-                            expiredAt: checkPassword.expiredAt,
                         },
                     },
                 },

--- a/src/modules/auth/controllers/auth.shared.controller.ts
+++ b/src/modules/auth/controllers/auth.shared.controller.ts
@@ -119,10 +119,10 @@ export class AuthSharedController {
             });
         }
 
-        const [matchPassword] = await Promise.all([
-            this.authService.validateUser(body.oldPassword, user.password),
-            this.userService.resetPasswordAttempt(user),
-        ]);
+        const matchPassword = this.authService.validateUser(
+            body.oldPassword,
+            user.password
+        );
         if (!matchPassword) {
             await this.userService.increasePasswordAttempt(user);
 
@@ -132,19 +132,20 @@ export class AuthSharedController {
             });
         }
 
-        const [password, checkPassword] = await Promise.all([
-            this.authService.createPassword(body.newPassword),
-            this.passwordHistoryService.findOneUsedByUser(
+        await this.userService.resetPasswordAttempt(user);
+
+        const password = this.authService.createPassword(body.newPassword);
+        const checkPassword =
+            await this.passwordHistoryService.findOneUsedByUser(
                 user._id,
-                user.password
-            ),
-        ]);
+                body.newPassword
+            );
         if (checkPassword) {
             const passwordPeriod =
                 await this.passwordHistoryService.getPasswordPeriod();
             throw new BadRequestException({
                 statusCode: ENUM_USER_STATUS_CODE_ERROR.PASSWORD_MUST_NEW,
-                message: 'user.error.passwordMustNew',
+                message: 'auth.error.passwordMustNew',
                 _metadata: {
                     customProperty: {
                         messageProperties: {

--- a/src/modules/password-history/services/password-history.service.ts
+++ b/src/modules/password-history/services/password-history.service.ts
@@ -11,6 +11,7 @@ import {
     IDatabaseGetTotalOptions,
 } from 'src/common/database/interfaces/database.interface';
 import { HelperDateService } from 'src/common/helper/services/helper.date.service';
+import { HelperHashService } from 'src/common/helper/services/helper.hash.service';
 import { PasswordHistoryCreateByAdminRequestDto } from 'src/modules/password-history/dtos/request/password-history.create-by-admin.request.dto';
 import { PasswordHistoryCreateRequestDto } from 'src/modules/password-history/dtos/request/password-history.create.request.dto';
 import { PasswordHistoryListResponseDto } from 'src/modules/password-history/dtos/response/password-history.list.response.dto';
@@ -33,6 +34,7 @@ export class PasswordHistoryService implements IPasswordHistoryService {
     constructor(
         private readonly configService: ConfigService,
         private readonly helperDateService: HelperDateService,
+        private readonly helperHashService: HelperHashService,
         private readonly passwordHistoryRepository: PasswordHistoryRepository
     ) {
         this.passwordPeriod = this.configService.get<number>(
@@ -101,17 +103,26 @@ export class PasswordHistoryService implements IPasswordHistoryService {
         options?: IDatabaseFindOneOptions
     ): Promise<PasswordHistoryDoc> {
         const today = this.helperDateService.create();
-
-        return this.passwordHistoryRepository.findOne<PasswordHistoryDoc>(
-            {
-                user,
-                password,
-                expiredAt: {
-                    $gte: today,
+        const allHistoryPasswords =
+            await this.passwordHistoryRepository.findAll<PasswordHistoryDoc>(
+                {
+                    user,
+                    expiredAt: { $gte: today },
                 },
-            },
-            options
-        );
+                options
+            );
+
+        for (const historyPassword of allHistoryPasswords) {
+            const isMatch = this.helperHashService.bcryptCompare(
+                password,
+                historyPassword.password
+            );
+            if (isMatch) {
+                return historyPassword;
+            }
+        }
+
+        return null;
     }
 
     async getTotal(


### PR DESCRIPTION
- Prevent resetting password attempt count when old password validation fails.
- Fix password history validation to compare the new password against the old password.
- Avoid direct hash comparison for passwords due to password salting.
- Correct assignment in `HelperDateService.create` when setting `mDate` to start or end of day.
- Improve error message for password reuse validation to provide clearer user guidance.