### PR TITLE
fix: absolute jwt keys path

### DIFF
--- a/src/modules/auth/services/auth.service.ts
+++ b/src/modules/auth/services/auth.service.ts
@@ -20,7 +20,7 @@ import { IUserDoc } from '@modules/user/interfaces/user.interface';
 import { AuthLoginResponseDto } from '@modules/auth/dtos/response/auth.login.response.dto';
 import { readFileSync } from 'fs';
 import { JwtService, JwtSignOptions } from '@nestjs/jwt';
-import { join } from 'path';
+import path from 'path';
 
 @Injectable()
 export class AuthService implements IAuthService {
@@ -66,7 +66,7 @@ export class AuthService implements IAuthService {
             'auth.jwt.accessToken.kid'
         );
         this.jwtAccessTokenPrivateKey = readFileSync(
-            join(
+            path.resolve(
                 process.cwd(),
                 this.configService.get<string>(
                     'auth.jwt.accessToken.privateKeyPath'
@@ -75,7 +75,7 @@ export class AuthService implements IAuthService {
             'utf8'
         );
         this.jwtAccessTokenPublicKey = readFileSync(
-            join(
+            path.resolve(
                 process.cwd(),
                 this.configService.get<string>(
                     'auth.jwt.accessToken.publicKeyPath'
@@ -91,7 +91,7 @@ export class AuthService implements IAuthService {
             'auth.jwt.refreshToken.kid'
         );
         this.jwtRefreshTokenPrivateKey = readFileSync(
-            join(
+            path.resolve(
                 process.cwd(),
                 this.configService.get<string>(
                     'auth.jwt.refreshToken.privateKeyPath'
@@ -100,7 +100,7 @@ export class AuthService implements IAuthService {
             'utf8'
         );
         this.jwtRefreshTokenPublicKey = readFileSync(
-            join(
+            path.resolve(
                 process.cwd(),
                 this.configService.get<string>(
                     'auth.jwt.refreshToken.publicKeyPath'


### PR DESCRIPTION
### The problem

When cloning the repo and running `docker compose up` following the default setup, the container fails with the following error:
```
[Nest] 50  - 06/12/2025, 7:18:45 PM   ERROR [ExceptionHandler] Error: ENOENT: no such file or directory, open '/app/keys/access-token.pem'

[... and others]
```

This happens because:
- The Docker image sets `WORKDIR /app` as its working directory.
- The `auth.service.ts` attempts to read the key file using:
	```javascript
	readFileSync(
	  join(
	    process.cwd(),
	    this.configService.get<string>('auth.jwt.accessToken.privateKeyPath')
	  ),
	  'utf8'
	);
	```
- If `.env` contains an absolute path (e.g., `/keys/access-token.pem`), `path.join()` wrongly prepends it with `/app`, resulting in `/app/keys/access-token.pem`, which doesn’t exist unless mounted exactly that way.

### Proposal
This PR updates the path resolution logic to use `path.resolve(...)` instead of `path.join(...)`, which properly handles both relative and absolute paths.

```.env
#.env
AUTH_JWT_ACCESS_TOKEN_PRIVATE_KEY_PATH=keys/access-token.pem
AUTH_JWT_ACCESS_TOKEN_PUBLIC_KEY_PATH=keys/access-token.pub
```
`path.resolve(process.cwd(), 'keys/access-token.pem')` correctly resolves to `/app/keys/access-token.pem`.

Alternatively, for absolute paths:
```.env
#.env 
AUTH_JWT_ACCESS_TOKEN_PRIVATE_KEY_PATH=/keys/access-token.pem
AUTH_JWT_ACCESS_TOKEN_PUBLIC_KEY_PATH=/keys/access-token.pub
```

`path.resolve(...)` will respect and use `/keys/access-token.pem` directly, without prepending /app.

NOTE: Im not sure if this change will affect other way of executing the project.