### PR TITLE
fix: increase-password-attempt pipeline invalid syntax

### DIFF
--- a/src/modules/user/services/user.service.ts
+++ b/src/modules/user/services/user.service.ts
@@ -46,7 +46,6 @@ import { UserUpdateStatusRequestDto } from '@modules/user/dtos/request/user.upda
 import { DatabaseHelperQueryContain } from '@common/database/decorators/database.decorator';
 import { UserUploadPhotoRequestDto } from '@modules/user/dtos/request/user.upload-photo.request.dto';
 import { UserCensorResponseDto } from '@modules/user/dtos/response/user.censor.response.dto';
-import { DatabaseService } from '@common/database/services/database.service';
 
 @Injectable()
 export class UserService implements IUserService {
@@ -59,7 +58,6 @@ export class UserService implements IUserService {
         private readonly helperDateService: HelperDateService,
         private readonly configService: ConfigService,
         private readonly helperStringService: HelperStringService,
-        private readonly databaseService: DatabaseService
     ) {
         this.usernamePrefix = this.configService.get<string>(
             'user.usernamePrefix'
@@ -405,12 +403,12 @@ export class UserService implements IUserService {
 
     async increasePasswordAttempt(
         repository: UserDoc,
-        options?: IDatabaseUpdateOptions
+        options?: IDatabaseUpdateOptions,
     ): Promise<UserDoc> {
-        return this.userRepository.updateRaw(
-            { _id: repository._id },
-            this.databaseService.aggregateIncrement('passwordAttempt', 1),
-            options
+        repository.passwordAttempt++
+        return this.userRepository.save(
+            repository,
+            options,
         );
     }
 


### PR DESCRIPTION
Hello,

Im not sure this is the desired way to fix this, however:

### The issue:

```javascript
async increasePasswordAttempt(
    repository: UserDoc,
    options?: IDatabaseUpdateOptions
): Promise<UserDoc> {
    return this.userRepository.updateRaw(
        { _id: repository._id },
        this.databaseService.aggregateIncrement('passwordAttempt', 1),
        options
    );
}
```

While running it as-is:
```
    message: "Data must be an array"
    err: {
      "message": "Data must be an array",
      "stack":
          Error: Data must be an array
              at UserRepository.updateRaw (.../src/common/database/bases/database.object-id.repository.ts:491:13)
              at UserService.increasePasswordAttempt (.../src/modules/user/services/user.service.ts:413:32)
              at AuthPublicController.loginWithCredential (/.../src/modules/auth/controllers/auth.public.controller.ts:97:37)
              at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    }
```

Even if you wrap it as array:

```javascript
async increasePasswordAttempt(
    repository: UserDoc,
    options?: IDatabaseUpdateOptions
): Promise<UserDoc> {
    return this.userRepository.updateRaw(
        { _id: repository._id },
        [ this.databaseService.aggregateIncrement('passwordAttempt', 1) ],
        options
    );
}
```

```
Invalid update pipeline operator: "$inc"
```