### PR TITLE
feat(projection): added option to use projection on find

### DIFF
--- a/src/common/database/bases/database.object-id.repository.ts
+++ b/src/common/database/bases/database.object-id.repository.ts
@@ -61,6 +61,10 @@ export class DatabaseObjectIdRepositoryBase<
             }),
         });
 
+        if (options?.projection) {
+            repository.projection(options.projection);
+        }
+
         if (options?.select) {
             repository.select(options.select);
         }
@@ -109,6 +113,10 @@ export class DatabaseObjectIdRepositoryBase<
             }),
         });
 
+        if (options?.projection) {
+            repository.projection(options.projection);
+        }
+
         if (options?.select) {
             repository.select(options.select);
         }
@@ -150,6 +158,10 @@ export class DatabaseObjectIdRepositoryBase<
                 deleted: false,
             }),
         } as any);
+
+        if (options?.projection) {
+            repository.projection(options.projection);
+        }
 
         if (options?.select) {
             repository.select(options.select);

--- a/src/common/database/bases/database.uuid.repository.ts
+++ b/src/common/database/bases/database.uuid.repository.ts
@@ -55,6 +55,10 @@ export class DatabaseUUIDRepositoryBase<
             }),
         });
 
+        if (options?.projection) {
+            repository.projection(options.projection);
+        }
+
         if (options?.select) {
             repository.select(options.select);
         }
@@ -103,6 +107,10 @@ export class DatabaseUUIDRepositoryBase<
             }),
         });
 
+        if (options?.projection) {
+            repository.projection(options.projection);
+        }
+
         if (options?.select) {
             repository.select(options.select);
         }
@@ -142,6 +150,10 @@ export class DatabaseUUIDRepositoryBase<
                 deleted: false,
             }),
         });
+
+        if (options?.projection) {
+            repository.projection(options.projection);
+        }
 
         if (options?.select) {
             repository.select(options.select);

--- a/src/common/database/interfaces/database.interface.ts
+++ b/src/common/database/interfaces/database.interface.ts
@@ -10,6 +10,7 @@ export type IDatabaseDocument<T> = HydratedDocument<T>;
 // Find
 export interface IDatabaseOptions {
     select?: Record<string, boolean | number> | string;
+    projection?: Record<string, any>;
     join?: boolean | PopulateOptions | PopulateOptions[];
     session?: ClientSession;
     withDeleted?: boolean;


### PR DESCRIPTION
In my current project I had to add the option to use `projection` in the existing `.findXX` methods.

The existing select option in Mongoose is used to include or exclude specific fields from the query result. 
It supports only simple field-level filtering, like:

```
select: 'name email' // or { name: 1, email: 1 }
```

However, there are scenarios where we need computed or transformed fields returned by the query, such as:

1. Extracting nested elements - first/last item in an array
2. Handling conditional values - such as $ifNull
3. Resolving dynamic fields - such as $getField

By allowing an optional `projection` field in IDatabaseOptions, we give services/repositories the ability to define advanced projections using MongoDB’s syntax, 

From my understanding, this is not possible with just `select`.

---

Decline it or accept if this could be helpful to y'all.