### PR TITLE
fix(social-login): no password-expired on social login

### DIFF
--- a/src/modules/auth/utils/auth.util.ts
+++ b/src/modules/auth/utils/auth.util.ts
@@ -476,6 +476,7 @@ export class AuthUtil {
      * @returns True if the password has expired (current date > expiration date), false otherwise
      */
     checkPasswordExpired(passwordExpired: Date): boolean {
+        if (!passwordExpired) { return false; }
         const today: Date = this.helperService.dateCreate();
         return today > passwordExpired;
     }


### PR DESCRIPTION
When a user signs up via a social provider, we intentionally do not set `user.passwordExpired` (for obvious reasons — no local password involved).
However, in `UserGuard`, during the call to `userService.validateUserGuard`, we currently run the following logic:

```javascript
const checkPasswordExpired: boolean = this.authUtil.checkPasswordExpired(user.passwordExpired);
if (checkPasswordExpired) {
    throw new ForbiddenException({
        statusCode: EnumUserStatus_CODE_ERROR.passwordExpired,
        message: 'auth.error.passwordExpired',
    });
} else if (requiredVerified === true && user.isVerified !== true) {
    throw new ForbiddenException({
        statusCode: EnumUserStatus_CODE_ERROR.emailNotVerified,
        message: 'user.error.emailNotVerified',
    });
}
```
The key problem is the call to: `this.authUtil.checkPasswordExpired(user.passwordExpired)`.

In the social login case, `user.passwordExpired` is always `null`.
This value is then passed to the following utility method:

```javascript
checkPasswordExpired(passwordExpired: Date): boolean {
    const today: Date = this.helperService.dateCreate();
    return today > passwordExpired;
}
```

Since the comparison is performed against a `null` value, the date check behaves incorrectly and results in users being blocked by the guard, even though password expiration should not apply to social-authenticated users.